### PR TITLE
compat: add NetBox 4.5.x support

### DIFF
--- a/nb_risk/__init__.py
+++ b/nb_risk/__init__.py
@@ -11,8 +11,8 @@ class NbriskConfig(PluginConfig):
     version = __version__
     author = "Renato Almeida de Oliveira Zaroubin"
     author_email = "renato.almeida.oliveira@gmail.com"
-    min_version = "4.1.0"
-    max_version = "4.1.99"
+    min_version = "4.5.0"
+    max_version = "4.5.99"
     required_settings = []
     default_settings = {
         "supported_assets": [

--- a/nb_risk/api/serializers.py
+++ b/nb_risk/api/serializers.py
@@ -1,10 +1,7 @@
 from rest_framework import serializers
-from django.contrib.contenttypes.models import ContentType
-from netbox.api.fields import ChoiceField, ContentTypeField, SerializedPKRelatedField
-from utilities.api import get_serializer_for_model
-
-
+from netbox.api.fields import ChoiceField, ContentTypeField, GFKSerializerField
 from netbox.api.serializers import NetBoxModelSerializer
+from core.models import ObjectType
 
 from .. import models, choices
 
@@ -43,7 +40,6 @@ class ThreatEventSerializer(NetBoxModelSerializer):
     relevance = ChoiceField(choices=choices.RelevanceChoices)
     likelihood = ChoiceField(choices=choices.LikelihoodChoices)
 
-
     def get_display(self, obj):
         return obj.name
 
@@ -60,13 +56,11 @@ class ThreatEventSerializer(NetBoxModelSerializer):
             "impact",
             "vulnerability",
         ]
-
         brief_fields = ['id', 'url', 'display', 'name', 'description']
 
 # Vulnerability Serializers
 
 class VulnerabilitySerializer(NetBoxModelSerializer):
-    
     url = serializers.HyperlinkedIdentityField(view_name="plugins-api:nb_risk-api:vulnerability-detail")
     display = serializers.SerializerMethodField('get_display')
 
@@ -83,7 +77,6 @@ class VulnerabilitySerializer(NetBoxModelSerializer):
             "cve",
             "description",
         ]
-
         brief_fields = ['id', 'url', 'display', 'name', 'description']
 
 
@@ -92,32 +85,31 @@ class VulnerabilitySerializer(NetBoxModelSerializer):
 class VulnerabilityAssignmentSerializer(NetBoxModelSerializer):
     url = serializers.HyperlinkedIdentityField(view_name="plugins-api:nb_risk-api:vulnerabilityassignment-detail")
     display = serializers.SerializerMethodField('get_display')
+
+    # Use ObjectType (NetBox wrapper) filtered via the AssetTypes Q object for the content type field.
+    # Pass the Q object correctly as a positional filter argument.
     asset_object_type = ContentTypeField(
-        queryset=ContentType.objects.filter(choices.AssetTypes),
+        queryset=ObjectType.objects.filter(choices.AssetTypes),
         required=True,
     )
-    asset = serializers.SerializerMethodField('get_asset')
+
+    # GFKSerializerField replaces the manual get_serializer_for_model() pattern (NetBox 4.5+)
+    asset = GFKSerializerField(read_only=True)
+
     vulnerability = serializers.SlugRelatedField(slug_field="name", queryset=models.Vulnerability.objects.all())
 
-    asset_id = serializers.IntegerField(source='asset.id', write_only=True)
+    asset_id = serializers.IntegerField(write_only=True)
 
     def validate(self, data):
-        asset_id = data['asset']['id']
-        asset_object_type = data['asset_object_type']
-        asset = asset_object_type.get_object_for_this_type(id=asset_id)
-        data['asset'] = asset
+        asset_id = data.get('asset_id')
+        asset_object_type = data.get('asset_object_type')
+        if asset_id and asset_object_type:
+            asset = asset_object_type.get_object_for_this_type(id=asset_id)
+            data['asset_id'] = asset.pk
         return super().validate(data)
 
-    def get_asset(self, obj):
-        if obj.asset is None:
-            return None
-        serializer = get_serializer_for_model(obj.asset)
-        context = {'request': self.context['request']}
-        return serializer(obj.asset, context=context, nested=True).data
-    
     def get_display(self, obj):
         return obj.name
-
 
     class Meta:
         model = models.VulnerabilityAssignment
@@ -137,10 +129,8 @@ class VulnerabilityAssignmentSerializer(NetBoxModelSerializer):
 class RiskSerializer(NetBoxModelSerializer):
     url = serializers.HyperlinkedIdentityField(view_name="plugins-api:nb_risk-api:risk-detail")
     display = serializers.SerializerMethodField('get_display')
-    
     threat_event = serializers.SlugRelatedField(slug_field="name", queryset=models.ThreatEvent.objects.all())
 
-   
     def get_display(self, obj):
         return obj.name
 
@@ -162,11 +152,11 @@ class RiskSerializer(NetBoxModelSerializer):
 class ControlSerializer(NetBoxModelSerializer):
     url = serializers.HyperlinkedIdentityField(view_name="plugins-api:nb_risk-api:control-detail")
     display = serializers.SerializerMethodField('get_display')
-    risk = RiskSerializer(many=True,required=False, allow_null=True, nested=True)
+    risk = RiskSerializer(many=True, required=False, allow_null=True, nested=True)
 
     def get_display(self, obj):
         return obj.name
-    
+
     class Meta:
         model = models.Control
         fields = [
@@ -176,5 +166,5 @@ class ControlSerializer(NetBoxModelSerializer):
             "name",
             "description",
             "notes",
-            "risk"
+            "risk",
         ]

--- a/nb_risk/api/views.py
+++ b/nb_risk/api/views.py
@@ -6,35 +6,35 @@ from . import serializers
 # ThreatSource ViewSets
 
 class ThreatSourceViewSet(NetBoxModelViewSet):
-    queryset = models.ThreatSource.objects.all()
+    queryset = models.ThreatSource.objects.all().order_by('name')
     serializer_class = serializers.ThreatSourceSerializer
-    
+
 # ThreatEvent ViewSets
 
 class ThreatEventViewSet(NetBoxModelViewSet):
-    queryset = models.ThreatEvent.objects.all()
+    queryset = models.ThreatEvent.objects.all().order_by('name')
     serializer_class = serializers.ThreatEventSerializer
 
 # Vulnerability ViewSets
 
 class VulnerabilityViewSet(NetBoxModelViewSet):
-    queryset = models.Vulnerability.objects.all()
+    queryset = models.Vulnerability.objects.all().order_by('name')
     serializer_class = serializers.VulnerabilitySerializer
-    
+
 # VulnerabilityAssignment ViewSets
 
 class VulnerabilityAssignmentViewSet(NetBoxModelViewSet):
-    queryset = models.VulnerabilityAssignment.objects.all()
+    queryset = models.VulnerabilityAssignment.objects.all().order_by('pk')
     serializer_class = serializers.VulnerabilityAssignmentSerializer
 
 # Risk ViewSets
 
 class RiskViewSet(NetBoxModelViewSet):
-    queryset = models.Risk.objects.all()
+    queryset = models.Risk.objects.all().order_by('name')
     serializer_class = serializers.RiskSerializer
 
 # Control ViewSets
 
 class ControlViewSet(NetBoxModelViewSet):
-    queryset = models.Control.objects.all()
+    queryset = models.Control.objects.all().order_by('name')
     serializer_class = serializers.ControlSerializer

--- a/nb_risk/models.py
+++ b/nb_risk/models.py
@@ -36,6 +36,9 @@ class ThreatSource(NetBoxModel):
     def get_absolute_url(self):
         return reverse("plugins:nb_risk:threatsource", args=[self.pk])
 
+    class Meta:
+        ordering = ('name',)
+
 
 # Vulnerability Model
 
@@ -76,6 +79,7 @@ class Vulnerability(NetBoxModel):
         return reverse("plugins:nb_risk:vulnerability", args=[self.pk])
 
     class Meta:
+        ordering = ('name',)
         verbose_name = "Vulnerability"
         verbose_name_plural = "Vulnerabilities"
         constraints = (
@@ -168,6 +172,9 @@ class ThreatEvent(NetBoxModel):
     def get_absolute_url(self):
         return reverse("plugins:nb_risk:threatevent", args=[self.pk])
 
+    class Meta:
+        ordering = ('name',)
+
 
 # Risk Model
 
@@ -239,6 +246,9 @@ class Risk(NetBoxModel):
     def get_absolute_url(self):
         return reverse("plugins:nb_risk:risk", args=[self.pk])
 
+    class Meta:
+        ordering = ('name',)
+
 
 # Control Model
 
@@ -264,3 +274,6 @@ class Control(NetBoxModel):
 
     def get_absolute_url(self):
         return reverse("plugins:nb_risk:control", args=[self.pk])
+
+    class Meta:
+        ordering = ('name',)

--- a/nb_risk/template_content.py
+++ b/nb_risk/template_content.py
@@ -1,14 +1,11 @@
 from netbox.plugins import PluginTemplateExtension
 from netbox.plugins.utils import get_plugin_config
-from django.conf import settings
-from packaging import version
-
-NETBOX_CURRENT_VERSION = version.parse(settings.VERSION)
 
 
 def create_button(model_name):
     class Button(PluginTemplateExtension):
-        model = model_name
+        # NetBox 4.3+ requires `models` (list) instead of the deprecated singular `model`
+        models = [model_name]
 
         def buttons(self):
             return self.render("nb_risk/vulnerability_assignment_button.html")

--- a/nb_risk/views.py
+++ b/nb_risk/views.py
@@ -5,7 +5,7 @@ from netbox.views import generic
 from dcim.models import Device, Site
 from tenancy.models import Tenant
 from virtualization.models import VirtualMachine
-from core.models import ObjectType as ContentType
+from core.models import ObjectType
 from ipam.models import IPAddress
 
 from netbox.plugins.utils import get_plugin_config

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
     url='https://github.com/renatoalmeidaoliveira/nbrisk',
     author='Renato Almdida Oliveira',
     author_email='renato.almeida.oliveira@gmail.com',
+    python_requires='>=3.12',
     install_requires=[],
     packages=find_packages(),
     include_package_data=True,
@@ -39,5 +40,7 @@ setup(
         'Development Status :: 2 - Pre-Alpha',
         'Framework :: Django',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ]
 )


### PR DESCRIPTION
- __init__.py: bump min_version to 4.5.0, max_version to 4.5.99
- views.py: remove shadowed 'ObjectType as ContentType' alias that clobbered Django's ContentType import; import ObjectType cleanly
- template_content.py: replace deprecated singular 'model' attribute with 'models' list on PluginTemplateExtension (required since 4.3); remove unused packaging/version import
- api/views.py: add .order_by() to all ViewSet querysets to prevent QuerySetNotOrdered exceptions on paginated API calls (NetBox 4.3.5+)
- api/serializers.py: switch ContentTypeField to use core.models.ObjectType instead of Django ContentType; migrate GFK serialization from manual get_serializer_for_model() pattern to GFKSerializerField (NetBox 4.5+); remove unused get_serializer_for_model import
- models.py: add Meta.ordering = ('name',) to all models to support deterministic API pagination
- setup.py: add python_requires>=3.12, update Python classifiers